### PR TITLE
Use CDN link to avoid impact China site.

### DIFF
--- a/src/FontAwesomeAsset.php
+++ b/src/FontAwesomeAsset.php
@@ -26,7 +26,9 @@ class FontAwesomeAsset extends AssetBundle
      */
     public $js = [
         // font awesome free version (can be overridden from yii2 asset manager)
-        'https://use.fontawesome.com/releases/v5.13.0/js/all.js'
+        //'https://use.fontawesome.com/releases/v5.13.0/js/all.js'
+        // Better use CDN version, or else China site would have issue to get the JS.  Below CDN available for worldwide
+        'https://cdn.bootcss.com/font-awesome/5.3.1/js/all.js'
     ];
 
     /**


### PR DESCRIPTION
// Better use CDN version, or else China site would have issue to get the JS.  Below CDN available for worldwide
        'https://cdn.bootcss.com/font-awesome/5.3.1/js/all.js'

## Scope
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-icons/blob/master/CHANGE.md)):

-
-
-

## Related Issues
If this is related to an existing ticket, include a link to it as well.