### PR TITLE
avoid PHP warning if $framework argument is null

### DIFF
--- a/src/Icon.php
+++ b/src/Icon.php
@@ -166,7 +166,7 @@ class Icon
      */
     protected static function getFramework($framework = null, $method = 'show')
     {
-        $len = strlen($framework);
+        $len = empty($framework)?0:strlen($framework);
         if ($len > 0 && !in_array($framework, array_keys(self::$_frameworks))) {
             $replace = ['{framework}' => $framework, '{method}' => 'Icon::' . $method];
             throw new InvalidConfigException(strtr(self::FRAMEWORK_INVALID, $replace));


### PR DESCRIPTION
## Scope
This pull request includes a

- [X] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-icons/blob/master/CHANGE.md)):

- Filter strlen for null values to avoid deprecation warnings:
$len = empty($framework)?0:strlen($framework);
